### PR TITLE
Release: merge develop into main

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -21,4 +21,4 @@ jobs:
             '[scope] bug, [scope] documentation, [scope] enhancement, [scope]
             maintenance, [scope] significant, [maintainer] release'
           pull-request-number: ${{ github.event.pull_request.number }}
-          disable-reviews: false
+          disable-reviews: true

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -30,10 +30,8 @@ jobs:
             --base main \
             --head develop \
             --title "Release: merge develop into main" \
-            --body "This pull request is created automatically to
-            trigger the release pipeline. It merges the accumulated
-            changes from \`develop\` into \`main\`.
-            ⚠️ Note: This PR is labeled \`[maintainer] release\` and is
-            excluded from release notes and version bump logic."
+            --label "[maintainer] release" \
+            --body "This pull request is created automatically to trigger the release pipeline. It  merges the accumulated changes from \`develop\` into \`main\`.
+            ⚠️ Note: This PR is labeled \`[maintainer] release\` and is excluded from release notes and version bump logic."
         env:
           GITHUB_TOKEN: ${{ secrets.GH_API_PERSONAL_ACCSESS_TOKEN }}


### PR DESCRIPTION
This pull request is created automatically to trigger the release pipeline. It  merges the accumulated changes from `develop` into `main`.
  ⚠️ Note: This PR is labeled `[maintainer] release` and is excluded from release notes and version bump logic.